### PR TITLE
Hint for absolute file path in Quarto

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ citeproc: false
 ---
 ```
 
+**Please Note**: In some OS environments it might be necessary to use the complete absolute path to the .lua file for the filter, e.g.
+
+```
+filters:
+  - /home/user/_extensions/pandoc-ext/section-bibliographies/section-bibliographies.lua
+```
+
 ### R Markdown
 
 Use `pandoc_args` to invoke the filter. See the [R Markdown
@@ -73,12 +80,6 @@ output:
   word_document:
     pandoc_args: ['--lua-filter=section-bibliographies.lua']
 ---
-```
-**Please Note**: In some OS environments it might be necessary to use the complete absolute path to the .lua file for the filter, e.g.
-
-```
-filters:
-  - /home/user/_extensions/pandoc-ext/section-bibliographies/section-bibliographies.lua
 ```
 
 Configuration

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ output:
     pandoc_args: ['--lua-filter=section-bibliographies.lua']
 ---
 ```
+**Please Note**: In some OS environments it might be necessary to use the complete absolute path to the .lua file for the filter, e.g.
+
+```
+filters:
+  - /home/user/_extensions/pandoc-ext/section-bibliographies/section-bibliographies.lua
+```
 
 Configuration
 ------------------------------------------------------------------


### PR DESCRIPTION
In some OS environments, the full absolute path to the .lua file must be used for the filter. This has been added with the respective commits.